### PR TITLE
Define a workflow to automatically update the snap on new beta versions

### DIFF
--- a/.github/scripts/check-new-version.py
+++ b/.github/scripts/check-new-version.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python3
+
+import logging
+import lxml.html
+import sys
+from http import HTTPStatus
+from packaging import version
+from urllib import request
+
+
+ROOT_URL = "https://ftp.mozilla.org/pub/thunderbird/candidates/"
+
+BETA = "beta"
+RELEASE = "release"
+ESR = "esr"
+CHANNELS = (BETA, RELEASE, ESR)
+
+
+def get_latest_build(candidate):
+    result = request.urlopen(ROOT_URL + candidate + "-candidates/")
+    if result.getcode() != HTTPStatus.OK:
+        logging.error("failed to fetch the list of builds for {}"
+                      .format(candidate))
+        return 0
+    builds = lxml.html.fromstring(result.read())
+    builds = builds.xpath("//a[contains(@href,'-candidates/build')]/text()")
+    builds.sort()
+    return int(builds[-1][:-1].split('build')[-1])
+
+
+def test_version(current_version, candidate):
+    nv = version.parse(candidate)
+    cv = version.parse(current_version.split('-')[0])
+    if nv >= cv:
+        build = get_latest_build(candidate)
+        if nv > cv or build > int(current_version.split('-')[1]):
+            return '{}-{}'.format(candidate, build)
+    return None
+
+
+def check_new_candidates(channel, current_version):
+    new_version = current_version
+    result = request.urlopen(ROOT_URL)
+    if result.getcode() != HTTPStatus.OK:
+        sys.exit("failed to fetch list of candidates")
+    candidates = lxml.html.fromstring(result.read())
+    candidates = candidates.xpath("//a[contains(@href,'-candidates/')]/text()")
+    candidates = [c[:-12] for c in candidates if not c.startswith("None")]
+    for candidate in candidates:
+        if channel == BETA and "b" not in candidate:
+            continue
+        if channel == ESR and not candidate.endswith("esr"):
+            continue
+        if channel == RELEASE and \
+           ("b" in candidate or candidate.endswith("esr")):
+            continue
+        new_version = test_version(new_version, candidate) or new_version
+    if new_version != current_version:
+        logging.info("new version: {} > {}"
+                     .format(new_version, current_version))
+        print(new_version)
+
+
+if __name__ == '__main__':
+    logging.getLogger().setLevel(logging.INFO)
+    if len(sys.argv) != 3:
+        logging.error("Usage: {program} channel current_version"
+                      .format(program=sys.argv[0]))
+        sys.exit(1)
+    assert sys.argv[1] in CHANNELS
+    check_new_candidates(*sys.argv[1:])

--- a/.github/workflows/bump-beta-version.yml
+++ b/.github/workflows/bump-beta-version.yml
@@ -1,0 +1,37 @@
+name: New version check
+
+on:
+  schedule:
+    # 3 times a day should be enough
+    - cron: '07 7,15,23 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-new-beta:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: beta
+      - name: Extract current version
+        id: extract-current-version
+        run: |
+          currentversion=$(sed -n 's/^version: "\(.*\)"$/\1/p' snapcraft.yaml)
+          echo "::set-output name=currentversion::$currentversion"
+      - name: Install python deps
+        run: sudo apt update && sudo apt install python3-lxml python3-packaging
+      - name: Fetch new version
+        id: fetch-new-version-beta
+        run: |
+          version=$(./.github/scripts/check-new-version.py beta ${{ steps.extract-current-version.outputs.currentversion }})
+          echo "::set-output name=version::$version"
+      - name: Update snapcraft.yaml with the new version
+        if: steps.fetch-new-version-beta.outputs.version
+        run: |
+          version=${{ steps.fetch-new-version-beta.outputs.version }}
+          sed -i "s/^version: \"\(.*\)\"$/version: \"$version\"/" snapcraft.yaml
+          git add snapcraft.yaml
+          git config user.name "Update Bot"
+          git config user.email "actions@github.com"
+          git commit -m "Update to $version."
+          git push

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: thunderbird
-version: "97.0b2"
+version: "97.0b2-1"
 summary: Mozilla Thunderbird email application
 description: Thunderbird is a free email application that’s easy to set up and customize - and it’s loaded with great features!
 confinement: strict


### PR DESCRIPTION
Based on the work for Olivier on firefox, it's checking for new versions on crontab events and updating the snapcraft.yaml version when there is one, an updated snap is going to build on launchpad in reaction to the vcs change