### PR TITLE
Enable MOZILLA_OFFICIAL flag

### DIFF
--- a/mozconfig.in
+++ b/mozconfig.in
@@ -8,4 +8,4 @@ ac_add_options --disable-tests
 ac_add_options --without-wasm-sandboxed-libraries
 ac_add_options CC=clang-15
 ac_add_options CXX=clang++-15
-ac_add_options MOZ_TELEMETRY_REPORTING=
+mk_add_options MOZILLA_OFFICIAL=1


### PR DESCRIPTION
@seb128 After further digging, Andrei discovered that it would be ideal to use the MOZILLA_OFFICIAL flag instead of MOZ_TELEMETRY_REPORTING.

While MOZ_TELEMETRY_REPORTING works for enabling telemetry, MOZILLA_OFFICIAL enables telemetry and creates an "official" build of Thunderbird. This flag is intended to be used for Thunderbird builds by Mozilla and builds by Linux distros.