### PR TITLE
[Beta] Use hunspell dictionaries from the host filesystem.

### DIFF
--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+# Copyright (C) 2022 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+host_hunspell=/var/lib/snapd/hostfs/usr/share/hunspell
+
+if [ ! -d  $host_hunspell ]; then
+    echo "No host hunspell, skipping"
+    exit 0
+fi
+
+DICPATH=$SNAP_COMMON/snap-hunspell
+
+if [ -d "$DICPATH" ]; then
+    # Clean up on each refresh to ensure we have an up-to-date list
+    # of host dictionaries.
+    find "$DICPATH" -type l -name "*.dic" -or -name "*.aff" -exec rm {} + || true
+else
+    mkdir -p "$DICPATH"
+fi
+
+# We deliberately don't directly use the host dictionary files.
+# Instead, we use their names to know which ones the user has
+# installed on their system, and we use the corresponding ones
+# we primed in '$SNAP/usr/share/hunspell' in our 'hunspell' part.
+#
+# - We don't set DICPATH=/var/lib/snapd/hostfs/usr/share/hunspell
+#   to avoid potential incompatibility due to different hunspell
+#   versions inside the snap and outside on the host.  See:
+#   https://github.com/snapcore/snapd/pull/11025
+#
+# - We don't set DICPATH="$SNAP/usr/share/hunspell" because that
+#   would result in all available dictionaries we primed in our
+#   'hunspell' part being displayed in Thunderbird's interface,
+#   presenting an overwhelming number of options to the user.
+#   So instead we only use those that were installed on the host.
+#   This way, the user could affect the dictionaries available to
+#   Thunderbird snap similarly to how they could for non-snap Thunderbird.
+for dic in $(find $host_hunspell/ -name "*.dic"); do
+    dic_file=$(basename $dic)
+    aff_file="${dic_file%%.dic}.aff"
+    ln -s $SNAP/usr/share/hunspell/${dic_file} $DICPATH/${dic_file}
+    ln -s $SNAP/usr/share/hunspell/${aff_file} $DICPATH/${aff_file}
+done

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -31,6 +31,7 @@ apps:
     command: thunderbird.launcher
     extensions: [gnome]
     environment:
+      DICPATH: "$SNAP_COMMON/snap-hunspell"
       GTK_USE_PORTAL: 1
       HOME: "$SNAP_USER_COMMON"
     plugs:
@@ -42,6 +43,7 @@ apps:
       - gsettings
       - gpg-keys
       - home
+      - host-usr-share-hunspell
       - network
       - network-control
       - opengl
@@ -61,6 +63,9 @@ plugs:
   dot-thunderbird:
     interface: personal-files
     read: [$HOME/.thunderbird]
+  host-usr-share-hunspell:
+    interface: system-files
+    read: [/var/lib/snapd/hostfs/usr/share/hunspell]
 
 parts:
   rust:
@@ -258,3 +263,7 @@ slots:
     interface: dbus
     bus: session
     name: org.mozilla.thunderbird
+
+hooks:
+  post-refresh:
+    plugs: [host-usr-share-hunspell]


### PR DESCRIPTION
Imitates Firefox' setup as in [1], ignoring compatibility stuff pertaining to the host-hunspell interface, which Thunderbird never had.

[1] https://github.com/canonical/firefox-snap/pull/53/


-------

### Verification

I had these hunspell dictionaries installed:

    hunspell-de-ch/oracular,now 20161207-12 all  [installiert]
    hunspell-en-us/oracular,now 1:2020.12.07-2 all  [installiert]

If I install the snap hereby produced, connect the interface and re-install it, I get in the `snap run --shell thunderbird`:

```
$ ls -la $SNAP_COMMON/snap-hunspell
total 8
drwxr-xr-x 2 root root 4096 Sep 19 09:55 .
drwxr-xr-x 4 root root 4096 Sep 19 09:53 ..
lrwxrwxrwx 1 root root   49 Sep 19 09:55 de_CH.aff -> /snap/thunderbird/x2/usr/share/hunspell/de_CH.aff
lrwxrwxrwx 1 root root   49 Sep 19 09:55 de_CH.dic -> /snap/thunderbird/x2/usr/share/hunspell/de_CH.dic
lrwxrwxrwx 1 root root   49 Sep 19 09:55 de_LI.aff -> /snap/thunderbird/x2/usr/share/hunspell/de_LI.aff
lrwxrwxrwx 1 root root   49 Sep 19 09:55 de_LI.dic -> /snap/thunderbird/x2/usr/share/hunspell/de_LI.dic
lrwxrwxrwx 1 root root   49 Sep 19 09:55 en_US.aff -> /snap/thunderbird/x2/usr/share/hunspell/en_US.aff
lrwxrwxrwx 1 root root   49 Sep 19 09:55 en_US.dic -> /snap/thunderbird/x2/usr/share/hunspell/en_US.dic
```

If I now do

    apt remove hunspell-en-us

and re-install the snap, I get

```
$ ls -la $SNAP_COMMON/snap-hunspell
total 8
drwxr-xr-x 2 root root 4096 Sep 19 09:56 .
drwxr-xr-x 4 root root 4096 Sep 19 09:53 ..
lrwxrwxrwx 1 root root   49 Sep 19 09:56 de_CH.aff -> /snap/thunderbird/x3/usr/share/hunspell/de_CH.aff
lrwxrwxrwx 1 root root   49 Sep 19 09:56 de_CH.dic -> /snap/thunderbird/x3/usr/share/hunspell/de_CH.dic
lrwxrwxrwx 1 root root   49 Sep 19 09:56 de_LI.aff -> /snap/thunderbird/x3/usr/share/hunspell/de_LI.aff
lrwxrwxrwx 1 root root   49 Sep 19 09:56 de_LI.dic -> /snap/thunderbird/x3/usr/share/hunspell/de_LI.dic
```


