### PR TITLE
Bug 1925353 - Change tmpdir to use user's cache directory

### DIFF
--- a/tmpdir
+++ b/tmpdir
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Set TMPDIR to be under the user's default Downloads dir
-export TMPDIR=$(xdg-user-dir DOWNLOAD)/thunderbird.tmp
+# Set TMPDIR to be under the user's default cache directory
+export TMPDIR=$XDG_CACHE_HOME/tmp
 
 exec "$@"


### PR DESCRIPTION
Currently, temporary files are stored in the user's Downloads directory. This changes that to use the user's standard temporary file directory, XDG_CACHE_HOME.