### PR TITLE
Plug unity7 interface for app-indicator dbusmenu

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -50,6 +50,7 @@ apps:
       - audio-playback
       - removable-media
       - u2f-devices
+      - unity7 # FIXME: remove once dbusmenu is allowed by desktop-legacy https://github.com/canonical/snapd/pull/14688
     slots:
       - dbus-daemon
 


### PR DESCRIPTION
The default desktop interfaces do not allow using com.canonical.dbusmenu on DBus to expose a list of actions from the app-indicator.

This can be dropped once https://github.com/canonical/snapd/pull/14688 is shipping.