### PR TITLE
[Beta] Bundle dictionaries in the snap

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,1 @@
+post-refresh

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -51,6 +51,10 @@ fi
 for dic in $(find $host_hunspell/ -name "*.dic"); do
     dic_file=$(basename $dic)
     aff_file="${dic_file%%.dic}.aff"
-    ln -s $SNAP/usr/share/hunspell/${dic_file} $DICPATH/${dic_file}
-    ln -s $SNAP/usr/share/hunspell/${aff_file} $DICPATH/${aff_file}
+    # Some dic,aff files in hunspell are themselves symlinks to other files,
+    # e.g. /usr/share/hunspell/fr_CH.dic -> fr.dic.
+    # That extra level of indirection somehow breaks spell checking.
+    # We therefore use readlink to link to the "real" file, not to a symlink.
+    ln -s "$(readlink -e $SNAP/usr/share/hunspell/${dic_file})" $DICPATH/${dic_file}
+    ln -s "$(readlink -e $SNAP/usr/share/hunspell/${aff_file})" $DICPATH/${aff_file}
 done

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -26,7 +26,7 @@ DICPATH=$SNAP_COMMON/snap-hunspell
 if [ -d "$DICPATH" ]; then
     # Clean up on each refresh to ensure we have an up-to-date list
     # of host dictionaries.
-    find "$DICPATH" -type l -name "*.dic" -or -name "*.aff" -exec rm {} + || true
+    find "$DICPATH" -type l \( -name "*.dic" -or -name "*.aff" \) -exec rm {} + || true
 else
     mkdir -p "$DICPATH"
 fi

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -70,6 +70,25 @@ plugs:
     read: [/var/lib/snapd/hostfs/usr/share/hunspell]
 
 parts:
+  # This is a temporary workaround to including the hunspell content
+  # snap, which would cause breakage in the Ubuntu desktop image build
+  # because of the Ubuntu policy.  See:
+  # https://bugzilla.mozilla.org/show_bug.cgi?id=1792006
+  #
+  # The definition of this part is essentially a copy of the
+  # corresponding part in hunspell-dictionaries-1-7-2004 by
+  # Buo-ren, Lin.
+  hunspell:
+    plugin: nil
+    override-build: |
+      set -eu
+      craftctl default
+      apt download $(apt-cache search '^hunspell-.*$' |
+        awk '!/myspell|dbgsym|tools|transitional|dependency/{printf "%s ", $1}')
+      find . -name "*.deb" -exec dpkg-deb -x {} "$CRAFT_PART_INSTALL" \;
+    prime:
+      - usr/share/hunspell
+
   rust:
     plugin: nil
     build-packages:


### PR DESCRIPTION
1. #18 is incomplete. We do not want to really use the host's dictionary files, but rather just use that information to know which dictionaries the snap should present the user (for spell checking etc.).

   As such, we were missing the part where we actually stage the dictionaries in the snap, and so were creating symlinks to nowhere in the post-refresh hook.

2. Additionally, I determined during testing that if the symlink introduced in the hook was pointed to a symlink as provided by hunspell and bundled by us (as e.g. /snap/thunderbird/xxxx/usr/share/hunspell/de_CH.dic -> de_CH_frami.dic), then the spell checking would not work.

3. The find command was not cleaning up *dic files.

4. The dictionaries were not being set up in a new installation, only upon refreshes, so I introduced the install hook too.

-----

## Verification

I have these dictionaries installed:

```
hunspell-de-ch/plucky,now 20161207-14 all  [installiert]
hunspell-de-de/plucky,now 20161207-14 all  [installiert]
hunspell-en-us/plucky,now 1:2020.12.07-3 all  [installiert]
```

If I install the snap hereby produced, connect the interface with `snap connect thunderbird:host-usr-share-hunspell` and re-install it, I get in the `snap run --shell thunderbird`:

```
$ ls -la $DICPATH
total 8
drwxr-xr-x 2 root root 4096 Jan  9 11:08 .
drwxr-xr-x 4 root root 4096 Jan  9 10:49 ..
lrwxrwxrwx 1 root root   55 Jan  9 11:08 de_BE.aff -> /snap/thunderbird/x2/usr/share/hunspell/de_DE_frami.aff
lrwxrwxrwx 1 root root   55 Jan  9 11:08 de_BE.dic -> /snap/thunderbird/x2/usr/share/hunspell/de_DE_frami.dic
lrwxrwxrwx 1 root root   55 Jan  9 11:08 de_CH.aff -> /snap/thunderbird/x2/usr/share/hunspell/de_CH_frami.aff
lrwxrwxrwx 1 root root   55 Jan  9 11:08 de_CH.dic -> /snap/thunderbird/x2/usr/share/hunspell/de_CH_frami.dic
lrwxrwxrwx 1 root root   55 Jan  9 11:08 de_DE.aff -> /snap/thunderbird/x2/usr/share/hunspell/de_DE_frami.aff
lrwxrwxrwx 1 root root   55 Jan  9 11:08 de_DE.dic -> /snap/thunderbird/x2/usr/share/hunspell/de_DE_frami.dic
lrwxrwxrwx 1 root root   55 Jan  9 11:08 de_LI.aff -> /snap/thunderbird/x2/usr/share/hunspell/de_CH_frami.aff
lrwxrwxrwx 1 root root   55 Jan  9 11:08 de_LI.dic -> /snap/thunderbird/x2/usr/share/hunspell/de_CH_frami.dic
lrwxrwxrwx 1 root root   55 Jan  9 11:08 de_LU.aff -> /snap/thunderbird/x2/usr/share/hunspell/de_DE_frami.aff
lrwxrwxrwx 1 root root   55 Jan  9 11:08 de_LU.dic -> /snap/thunderbird/x2/usr/share/hunspell/de_DE_frami.dic
lrwxrwxrwx 1 root root   49 Jan  9 11:08 en_US.aff -> /snap/thunderbird/x2/usr/share/hunspell/en_US.aff
lrwxrwxrwx 1 root root   49 Jan  9 11:08 en_US.dic -> /snap/thunderbird/x2/usr/share/hunspell/en_US.dic
```

(Note that that does not test the new `install` hook as the store auto-connect assertions cannot be used when installing this test snap as it did not go through the store.)

If I now do

    apt remove hunspell-en-us

and refresh the snap, the `en_US.{aff,dic}` are gone from that output.

I open Thunderbird and set up a dummy account, click to compose new message, and confirm that 

1. those dictionaries are in the spell checking list.
2. the wrong words (and only them) are correctly flagged as wrong.

as the picture below attests.

![ss2025-01-09-111434_749x437_scrot](https://github.com/user-attachments/assets/5f5acfef-8cbd-4062-89ca-34f9879ebff0)