### PR TITLE
Bug 1908870 - Allow reading from /etc/thunderbird

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -59,9 +59,9 @@ plugs:
   browser-sandbox:
     interface: browser-support
     allow-sandbox: true
-  etc-thunderbird-policies:
+  etc-thunderbird:
     interface: system-files
-    read: [/etc/thunderbird/policies]
+    read: [/etc/thunderbird]
   dot-thunderbird:
     interface: personal-files
     write: [$HOME/.thunderbird]


### PR DESCRIPTION
Similar to what we did in https://github.com/canonical/firefox-snap/pull/8 for firefox