### PR TITLE
[beta] Fix for EDS Calendar Integration extension

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -298,6 +298,7 @@ parts:
       - gnupg # Needed to use Thunderbird >78 with smartcards.
       - gnupg-agent # Needed to use Thunderbird >78 with smartcards.
       - libblkid1
+      - libecal-2.0-3 # Needed for EDS Calendar Integration extension.
       - libgcrypt20
       - libgpg-error0
       - libgpgme11 # Needed to use Thunderbird >78 with smartcards.


### PR DESCRIPTION
Fix for the [EDS Calendar Integration](https://addons.thunderbird.net/en-US/thunderbird/addon/eds-calendar-integration/) extension, which is currently broken in the Snap version of Thunderbird ([issue](https://github.com/balbusm/xul-ext-eds-calendar/issues/68)) due to inability to communicate with Evolution Data Server and access a library that is typically available on systems where EDS is installed.

**How to test**
- Build & install the Snap
- Connect the `calendar-service` interface to enable communication between the Snap and Evolution Data Server:

    ```bash
    sudo snap connect thunderbird:calendar-service
    ```
    > **Note**: This might not be required for snaps installed from the store if `calendar-service` has been approved for auto-connection for the Thunderbird snap.

* Install the [EDS Calendar Integration](https://addons.thunderbird.net/en-US/thunderbird/addon/eds-calendar-integration/) extension.
* Create a new calendar event in Thunderbird.
* Check that the event appears in Evolution / GNOME calendar / the calendar applet.