### PR TITLE
[monthly/stable] Update to 142.0b4-1.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,7 +13,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 name: thunderbird
-version: "128.14.0esr-1"
+version: "142.0b4-1"
 summary: Mozilla Thunderbird email application
 description: Thunderbird is a free email application that’s easy to set up and customize - and it’s loaded with great features!
 confinement: strict


### PR DESCRIPTION
This was a mistake as it is a beta release, but during the latest/esr/monthly transition I promoted it accidentally. We cannot revert monthly/stable to 141, as Thunderbird will refuse to open a profile from a newer version. (Even though the monthly track is brand new.)

Just wait until 142 is stabilized and then the issue rectifies itself.