### PR TITLE
Define NSS_DIR.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -208,6 +208,7 @@ parts:
     build-environment:
       - RUST_BACKTRACE: "full"
       - CARGO_PROFILE_RELEASE_BUILD_OVERRIDE_DEBUG: "true"
+      - NSS_DIR: "/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR"
     override-pull: |
       VERSION=$(craftctl get version | cut -d- -f1)
       BUILD=$(craftctl get version | cut -d- -f2)


### PR DESCRIPTION
Fixes:
```
   Compiling nss_sys v0.1.0 (https://github.com/mozilla/application-services?rev=cd04a4d1a74294ab08434d7a5a8152d25d25e53c#cd04a4d1)
error: failed to run custom build command for `nss_sys v0.1.0 (https://github.com/mozilla/application-services?rev=cd04a4d1a74294ab08434d7a5a8152d25d25e53c#cd04a4d1)`

Caused by:
  process didn't exit successfully: `/root/parts/thunderbird/build/target/release/build/nss_sys-25a9c1d021cc0dd4/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=NSS_DIR
  --- stderr
  thread 'main' panicked at /root/.cargo/git/checkouts/application-services-99bb257f08384f94/cd04a4d/components/support/rc_crypto/nss/nss_sys/build.rs:6:34:
  called `Result::unwrap()` on an `Err` value: NoNssDir
  stack backtrace:
     0: rust_begin_unwind
               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/std/src/panicking.rs:662:5
     1: core::panicking::panic_fmt
               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/panicking.rs:74:14
     2: core::result::unwrap_failed
               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/result.rs:1677:5
     3: core::result::Result<T,E>::unwrap
               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/result.rs:1102:23
     4: build_script_build::main
               at ./build.rs:6:5
     5: core::ops::function::FnOnce::call_once
               at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/ops/function.rs:250:5