### PR TITLE
Make sure distribution is built before the thunderbird part

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -172,6 +172,7 @@ parts:
     plugin: nil
     after:
       - cbindgen
+      - distribution
       - dump-syms
       - mozconfig
       - rust


### PR DESCRIPTION
Just to make sure the distribution part is build before the thunderbird part, I added it to the after section.