### PR TITLE
snap: set MOZ_APP_REMOTINGNAME so Wayland app_id matches desktop filename

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -43,6 +43,7 @@ apps:
       DICPATH: "$SNAP_COMMON/snap-hunspell"
       GTK_USE_PORTAL: 1
       HOME: "$SNAP_USER_COMMON"
+      MOZ_APP_REMOTINGNAME: "thunderbird_thunderbird"
     plugs:
       - avahi-observe
       - browser-sandbox


### PR DESCRIPTION
## Summary
- Adds `MOZ_APP_REMOTINGNAME=thunderbird_thunderbird` to `snapcraft.yaml` so Thunderbird's Wayland `xdg_toplevel.set_app_id` matches the snapd-generated `thunderbird_thunderbird.desktop` filename. Without this, KDE Plasma on Wayland shows a generic Wayland icon instead of Thunderbird's.
- Same one-line fix as [canonical/firefox-snap#74](https://github.com/canonical/firefox-snap/pull/74); already on the `beta` branch in 42a6e83, this forward-ports it to `stable`.

Fixes #41

## Test plan
Verified on Ubuntu 24.04 arm64 in a Multipass VM using `unsquashfs` + `snap try --devmode` against the published `thunderbird` snap (140.9.0esr-1, rev 1045), launching against a headless Weston compositor with `WAYLAND_DEBUG=1` to capture the `xdg_toplevel.set_app_id` value.

| Condition | Runtime app_id | Desktop filename | Match |
| --- | --- | --- | --- |
| Without `MOZ_APP_REMOTINGNAME` (reproduces bug) | `thunderbird-esr` | `thunderbird_thunderbird.desktop` | ✗ |
| With `MOZ_APP_REMOTINGNAME=thunderbird_thunderbird` (this PR) | `thunderbird_thunderbird` | `thunderbird_thunderbird.desktop` | ✓ |

- [x] Negative test: strip the env var from `meta/snap.yaml`, relaunch — app_id is `thunderbird-esr`, wouldn't match the installed `.desktop` filename.
- [x] Positive test: add the env var back, relaunch — app_id is `thunderbird_thunderbird`, matches the filename.
- [x] Manual confirmation on a real KDE Plasma Wayland session (taskbar icon renders correctly). See the screenshots in canonical/firefox-snap#74 for the equivalent Firefox before/after.