### PR TITLE
Relocate TMPDIR to $SNAP_USER_COMMON.

### DIFF
--- a/tmpdir
+++ b/tmpdir
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-# Set TMPDIR to be under the user's default Downloads dir
-export TMPDIR=$(xdg-user-dir DOWNLOAD)/thunderbird.tmp
+# /tmp is per-snap-private under strict confinement, so attachments saved
+# there are invisible to host handlers and attachment-open silently fails
+# (bz 2015280). Relocate TMPDIR to $SNAP_USER_COMMON, which maps to
+# ~/snap/thunderbird/common/ on the host, reachable to external handlers.
+export TMPDIR="$SNAP_USER_COMMON/tmp"
+mkdir -p "$TMPDIR"
 
 exec "$@"


### PR DESCRIPTION
Follow-up to the drop-override attempt (#29, reverted in 70307a7 after bz 2015280). $SNAP_USER_COMMON maps to ~/snap/thunderbird/common/ on the host, so xdg-document-portal can register attachments for external handlers, whereas the snap's private /tmp cannot be registered.

<img width="688" height="134" alt="image" src="https://github.com/user-attachments/assets/4d9f040c-7eca-429d-a9fb-1e5efa2475ec" />
