### PR TITLE
Remove gnome-platform folder

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -290,7 +290,7 @@ parts:
       # Workaround for LP: #2016358: create mount points for the gnome
       # content interface, while a proper fix is implemented in snapd.
       # Thanks to James Henstridge.
-      mkdir $CRAFT_PART_INSTALL/{gnome-platform,data-dir,data-dir/{icons,sounds,themes}}
+      mkdir $CRAFT_PART_INSTALL/{gpu-2404,data-dir,data-dir/{icons,sounds,themes}}
       craftctl default
     stage-packages:
       - opensc-pkcs11
@@ -300,7 +300,7 @@ parts:
       - usr/lib/*/opensc-pkcs11.so
       - usr/lib/*/pkcs11/opensc-pkcs11.so
       # Workaround for LP: #2016358 (see the 'override-stage' above).
-      - gnome-platform
+      - gpu-2404
       - data-dir/icons
       - data-dir/sounds
       - data-dir/themes


### PR DESCRIPTION
Currently, the snap creates the `gnome-platform` folder as a workaround for an old bug (LP #2016358).

This workaround isn't used anymore in Firefox, since [2a9002573535c8fb6158e46f601c3c541dea6a46](https://github.com/canonical/firefox-snap/pull/175/changes). Instead it is replaced by gpu-2404.

This PR does the same change.